### PR TITLE
Get the environment variables directly

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -1,5 +1,6 @@
 import time
 import hashlib
+import os
 from datetime import datetime
 from typing import Optional, Tuple
 from urllib.parse import urlparse
@@ -578,8 +579,8 @@ class GithubProvider(GitProvider):
 
         if deployment_type == 'app':
             try:
-                private_key = get_settings().github.private_key
-                app_id = get_settings().github.app_id
+                private_key =os.environ.get('GITHUB_PRIVATE_KEY')
+                app_id = os.environ.get('GITHUB_APP_ID')
             except AttributeError as e:
                 raise ValueError("GitHub app ID and private key are required when using GitHub app deployment") from e
             if not self.installation_id:


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated GitHub provider configuration to use environment variables (`GITHUB_PRIVATE_KEY` and `GITHUB_APP_ID`) instead of direct settings access. This enhances security and flexibility in configuration management.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_provider.py</strong><dd><code>Use Environment Variables for GitHub Credentials</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/github_provider.py
<li>Imported <code>os</code> module to access environment variables.<br> <li> Replaced hardcoded access to private key and app ID with environment <br>variables for GitHub app deployment.


</details>
    

  </td>
  <td><a href="https://github.com/emmettgreen/pr-agent/pull/4/files#diff-28979ec713529d6f619bcba0b9e6a3002d1164d47c70ccfea7f15306618a1a11">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

