### PR TITLE
Update the configuration

### DIFF
--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -25,7 +25,7 @@ ai_disclaimer=""  # Pro feature, full text for the AI disclaimer
 require_score_review=false
 require_tests_review=true
 require_estimate_effort_to_review=true
-require_can_be_split_review=false
+require_can_be_split_review=true
 # soc2
 require_soc2_ticket=false
 soc2_ticket_prompt="Does the PR description include a link to ticket in a project management system (e.g., Jira, Asana, Trello, etc.) ?"
@@ -36,10 +36,10 @@ ask_and_reflect=false
 #automatic_review=true
 persistent_comment=true
 extra_instructions = ""
-final_update_message = true
+final_update_message=false
 # review labels
 enable_review_labels_security=true
-enable_review_labels_effort=true
+enable_review_labels_effort=false
 # specific configurations for incremental review (/review -i)
 require_all_thresholds_for_incremental_review=false
 minimal_commits_for_incremental_review=0

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -55,17 +55,17 @@ publish_labels=true
 add_original_user_description=true
 generate_ai_title=false
 use_bullet_points=true
-extra_instructions = ""
-enable_pr_type=true
-final_update_message = true
+extra_instructions = "Write all descriptions in the imperative mood."
+enable_pr_type=false
+final_update_message=false
 enable_help_text=false
-enable_help_comment=true
+enable_help_comment=false
 # describe as comment
 publish_description_as_comment=false
 publish_description_as_comment_persistent=true
 ## changes walkthrough section
 enable_semantic_files_types=true
-collapsible_file_list='adaptive' # true, false, 'adaptive'
+collapsible_file_list='true' # true, false, 'adaptive'
 inline_file_summary=false # false, true, 'table'
 # markers
 use_description_markers=false
@@ -82,9 +82,9 @@ max_context_tokens=8000
 num_code_suggestions=4
 commitable_code_suggestions = false
 extra_instructions = ""
-rank_suggestions = false
+rank_suggestions=true
 enable_help_text=false
-persistent_comment=false
+persistent_comment=true
 # params for '/improve --extended' mode
 auto_extended_mode=true
 num_code_suggestions_per_chunk=5
@@ -95,7 +95,7 @@ final_clip_factor = 0.8
 
 [pr_add_docs] # /add_docs #
 extra_instructions = ""
-docs_style = "Sphinx Style" # "Google Style with Args, Returns, Attributes...etc", "Numpy Style", "Sphinx Style", "PEP257", "reStructuredText"
+docs_style = "Google" # "Google Style with Args, Returns, Attributes...etc", "Numpy Style", "Sphinx Style", "PEP257", "reStructuredText"
 
 [pr_update_changelog] # /update_changelog #
 push_changelog_changes=false


### PR DESCRIPTION
### **Description**
- Enable `require_can_be_split_review` to require PRs to be splittable.
- Set `final_update_message` and `enable_review_labels_effort` to false, turning off these features.
- Update `extra_instructions` to use imperative mood for descriptions.
- Change `collapsible_file_list` setting to true and update `docs_style` to Google.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Update Review Configuration Settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml
<li>Enable the requirement for PRs to be splittable.<br> <li> Disable the final update message and effort labels.<br> <li> Add imperative mood instruction for extra descriptions.<br> <li> Change collapsible file list setting to true and update documentation <br>style to Google.<br>


</details>
    

  </td>
  <td><a href="https://github.com/emmettgreen/pr-agent/pull/6/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+11/-11</a>&nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>