### PR TITLE
Update the configuration

### DIFF
--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -44,33 +44,57 @@ publish_labels = ...
 
 ## Configuration options
 
-### General configurations
-
 !!! example "Possible configurations"
 
-    - `publish_labels`: if set to true, the tool will publish the labels to the PR. Default is true.
+<table>
+  <tr>
+    <td><b>publish_labels</b></td>
+    <td>If set to true, the tool will publish the labels to the PR. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>publish_description_as_comment</b></td>
+    <td>If set to true, the tool will publish the description as a comment to the PR. If false, it will overwrite the original description. Default is false.</td>
+  </tr>
+  <tr>
+    <td><b>publish_description_as_comment_persistent</b></td>
+    <td>If set to true and `publish_description_as_comment` is true, the tool will publish the description as a persistent comment to the PR. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>add_original_user_description</b></td>
+    <td>If set to true, the tool will add the original user description to the generated description. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>generate_ai_title</b></td>
+    <td>If set to true, the tool will also generate an AI title for the PR. Default is false.</td>
+  </tr>
+  <tr>
+    <td><b>extra_instructions</b></td>
+    <td>Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ..."</td>
+  </tr>
+  <tr>
+    <td><b>enable_pr_type</b></td>
+    <td>If set to false, it will not show the `PR type` as a text value in the description content. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>final_update_message</b></td>
+    <td>If set to true, it will add a comment message [`PR Description updated to latest commit...`](https://github.com/Codium-ai/pr-agent/pull/499#issuecomment-1837412176) after finishing calling `/describe`. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>enable_semantic_files_types</b></td>
+    <td>If set to true, "Changes walkthrough" section will be generated. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>collapsible_file_list</b></td>
+    <td>If set to true, the file list in the "Changes walkthrough" section will be collapsible. If set to "adaptive", the file list will be collapsible only if there are more than 8 files. Default is "adaptive".</td>
+  </tr>
+  <tr>
+    <td><b>enable_help_text</b></td>
+    <td>If set to true, the tool will display a help text in the comment. Default is false.</td>
+  </tr>
+</table>
 
-    - `publish_description_as_comment`: if set to true, the tool will publish the description as a comment to the PR. If false, it will overwrite the original description. Default is false.
 
-    - `publish_description_as_comment_persistent`: if set to true and `publish_description_as_comment` is true, the tool will publish the description as a persistent comment to the PR. Default is true.
-
-    - `add_original_user_description`: if set to true, the tool will add the original user description to the generated description. Default is true.
-
-    - `generate_ai_title`: if set to true, the tool will also generate an AI title for the PR. Default is false.
-
-    - `extra_instructions`: Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".
-
-    - To enable `custom labels`, apply the configuration changes described [here](./custom_labels.md#configuration-options)
-
-    - `enable_pr_type`: if set to false, it will not show the `PR type` as a text value in the description content. Default is true.
-
-    - `final_update_message`: if set to true, it will add a comment message [`PR Description updated to latest commit...`](https://github.com/Codium-ai/pr-agent/pull/499#issuecomment-1837412176) after finishing calling `/describe`. Default is true.
-
-    - `enable_semantic_files_types`: if set to true, "Changes walkthrough" section will be generated. Default is true.
-    - `collapsible_file_list`: if set to true, the file list in the "Changes walkthrough" section will be collapsible. If set to "adaptive", the file list will be collapsible only if there are more than 8 files. Default is "adaptive".
-    - `enable_help_text`: if set to true, the tool will display a help text in the comment. Default is false.
-
-### Inline file summary 💎
+## Inline file summary 💎
 
 This feature enables you to copy the `changes walkthrough` table to the "Files changed" tab, so you can quickly understand the changes in each file while reviewing the code changes (diff view).
 
@@ -93,7 +117,7 @@ If you prefer to have the file summaries appear in the "Files changed" tab on ev
 **Note**: that this feature is currently available only for GitHub.
 
 
-### Markers template
+## Markers template
 
 To enable markers, set `pr_description.use_description_markers=true`.
 Markers enable to easily integrate user's content and auto-generated content, with a template-like mechanism.

--- a/docs/docs/tools/improve.md
+++ b/docs/docs/tools/improve.md
@@ -40,12 +40,24 @@ pr_commands = [
 ]
 
 [pr_code_suggestions]
-num_code_suggestions = ...
+num_code_suggestions_per_chunk = ...
 ...
 ```
 
 - The `pr_commands` lists commands that will be executed automatically when a PR is opened.
 - The `[pr_code_suggestions]` section contains the configurations for the `improve` tool you want to edit (if any)
+
+### Extended mode
+
+An extended mode, which does not involve PR Compression and provides more comprehensive suggestions, can be invoked by commenting on any PR by setting:
+```
+[pr_code_suggestions]
+auto_extended_mode=true
+```
+(This mode is true by default).
+
+Note that the extended mode divides the PR code changes into chunks, up to the token limits, where each chunk is handled separately (might use multiple calls to GPT-4 for large PRs).
+Hence, the total number of suggestions is proportional to the number of chunks, i.e., the size of the PR.
 
 
 
@@ -53,39 +65,57 @@ num_code_suggestions = ...
 
 !!! example "General options"
 
-    - `num_code_suggestions`: number of code suggestions provided by the 'improve' tool. Default is 4 for CLI, 0 for auto tools.
-    - `extra_instructions`: Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".
-    - `rank_suggestions`: if set to true, the tool will rank the suggestions, based on importance. Default is false.
-    - `commitable_code_suggestions`: if set to true, the tool will display the suggestions as commitable code comments. Default is false.
-    - `persistent_comment`: if set to true, the improve comment will be persistent, meaning that every new improve request will edit the previous one. Default is false.
-    - `enable_help_text`: if set to true, the tool will display a help text in the comment. Default is true.
+<table>
+  <tr>
+    <td><b>num_code_suggestions</b></td>
+    <td>Number of code suggestions provided by the 'improve' tool. Default is 4 for CLI, 0 for auto tools.</td>
+  </tr>
+  <tr>
+    <td><b>extra_instructions</b></td>
+    <td>Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".</td>
+  </tr>
+  <tr>
+    <td><b>rank_suggestions</b></td>
+    <td>If set to true, the tool will rank the suggestions, based on importance. Default is false.</td>
+  </tr>
+  <tr>
+    <td><b>commitable_code_suggestions</b></td>
+    <td>If set to true, the tool will display the suggestions as commitable code comments. Default is false.</td>
+  </tr>
+  <tr>
+    <td><b>persistent_comment</b></td>
+    <td>If set to true, the improve comment will be persistent, meaning that every new improve request will edit the previous one. Default is false.</td>
+  </tr>
+  <tr>
+    <td><b>enable_help_text</b></td>
+    <td>If set to true, the tool will display a help text in the comment. Default is true.</td>
+  </tr>
+</table>
 
-!!! example "params for '/improve --extended' mode"
+!!! example "params for 'extended' mode"
 
-    - `auto_extended_mode`: enable extended mode automatically (no need for the `--extended` option). Default is true.
-    - `num_code_suggestions_per_chunk`: number of code suggestions provided by the 'improve' tool, per chunk. Default is 5.
-    - `rank_extended_suggestions`: if set to true, the tool will rank the suggestions, based on importance. Default is true.
-    - `max_number_of_calls`: maximum number of chunks. Default is 5.
-    - `final_clip_factor`: factor to remove suggestions with low confidence. Default is 0.9.;
-
-## Extended mode
-
-An extended mode, which does not involve PR Compression and provides more comprehensive suggestions, can be invoked by commenting on any PR:
-```
-/improve --extended
-```
-
-or by setting:
-```
-[pr_code_suggestions]
-auto_extended_mode=true
-```
-(True by default).
-
-Note that the extended mode divides the PR code changes into chunks, up to the token limits, where each chunk is handled separately (might use multiple calls to GPT-4 for large PRs).
-Hence, the total number of suggestions is proportional to the number of chunks, i.e., the size of the PR.
-
-
+<table>
+  <tr>
+    <td><b>auto_extended_mode</b></td>
+    <td>Enable extended mode automatically (no need for the --extended option). Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>num_code_suggestions_per_chunk</b></td>
+    <td>Number of code suggestions provided by the 'improve' tool, per chunk. Default is 5.</td>
+  </tr>
+  <tr>
+    <td><b>rank_extended_suggestions</b></td>
+    <td>If set to true, the tool will rank the suggestions, based on importance. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>max_number_of_calls</b></td>
+    <td>Maximum number of chunks. Default is 5.</td>
+  </tr>
+  <tr>
+    <td><b>final_clip_factor</b></td>
+    <td>Factor to remove suggestions with low confidence. Default is 0.9.</td>
+  </tr>
+</table>
 
 ## Usage Tips
 
@@ -110,7 +140,7 @@ Hence, the total number of suggestions is proportional to the number of chunks, 
 
 !!! tip "Review vs. Improve tools comparison"
 
-    - The [`review`](https://pr-agent-docs.codium.ai/tools/review/) tool includes a section called 'Possible issues', that also provide feedback on the PR Code.
+    - The [review](https://pr-agent-docs.codium.ai/tools/review/) tool includes a section called 'Possible issues', that also provide feedback on the PR Code.
     In this section, the model is instructed to focus **only** on [major bugs and issues](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/pr_reviewer_prompts.toml#L71).
     - The `improve` tool, on the other hand, has a broader mandate, and in addition to bugs and issues, it can also give suggestions for improving code quality and making the code more efficient, readable, and maintainable (see [here](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/pr_code_suggestions_prompts.toml#L34)).
     - Hence, if you are interested only in feedback about clear bugs, the `review` tool might suffice. If you want a more detailed feedback, including broader suggestions for improving the PR code, also enable the `improve` tool to run on each PR.

--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -40,45 +40,6 @@ num_code_suggestions = ...
 - The `pr_commands` lists commands that will be executed automatically when a PR is opened.
 - The `[pr_reviewer]` section contains the configurations for the `review` tool you want to edit (if any).
 
-
-## Configuration options
-
-### General configurations
-
-!!! example "General options"
-    - <a name="num_code_suggestions"></a>`num_code_suggestions`: number of code suggestions provided by the 'review' tool. For manual comments, default is 4. For [PR-Agent app](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L142) auto tools, default is 0, meaning no code suggestions will be provided by the review tool, unless you manually edit `pr_commands`.
-    - <a name="inline_code_comments"></a>`inline_code_comments`: if set to true, the tool will publish the code suggestions as comments on the code diff. Default is false.
-    - <a name="persistent_comment"></a>`persistent_comment`: if set to true, the review comment will be persistent, meaning that every new review request will edit the previous one. Default is true.
-    - <a name="extra_instructions"></a>`extra_instructions`: Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".
-    - <a name="enable_help_text"></a>`enable_help_text`: if set to true, the tool will display a help text in the comment. Default is true.
-
-!!! example "Enable\\disable sub-sections"
-    You can enable or disable specific sub-sections of the review tool:
-
-    - <a name="require_score_review"></a>`require_score_review`: if set to true, the tool will add a section that scores the PR. Default is false.
-    - <a name="require_tests_review"></a>`require_tests_review`: if set to true, the tool will add a section that checks if the PR contains tests. Default is true.
-    - <a name="require_estimate_effort_to_review"></a>`require_estimate_effort_to_review`: if set to true, the tool will add a section that estimates the effort needed to review the PR. Default is true.
-    - <a name="require_can_be_split_review"></a>`require_can_be_split_review`: if set to true, the tool will add a section that checks if the PR contains several themes, and can be split into smaller PRs. Default is false.
-
-!!! example "SOC2 ticket compliance 💎"
-
-    This sub-tool checks if the PR description properly contains a ticket to a project management system (e.g., Jira, Asana, Trello, etc.), as required by SOC2 compliance. If not, it will add a label to the PR: "Missing SOC2 ticket".
-    
-    - <a name="require_soc2_ticket"></a>`require_soc2_ticket`: If set to true, the SOC2 ticket checker sub-tool will be enabled. Default is false.
-    - <a name="soc2_ticket_prompt"></a>`soc2_ticket_prompt`: The prompt for the SOC2 ticket review. Default is: `Does the PR description include a link to ticket in a project management system (e.g., Jira, Asana, Trello, etc.) ?`. Edit this field if your compliance requirements are different.
-
-!!! example "Adding PR labels"
-    You can enable the tool to add specific labels to the PR:
-
-    - <a name="enable_review_labels_security"></a>`enable_review_labels_security`: if set to true, the tool will publish a 'possible security issue' label if it detects a security issue. Default is true.
-    - <a name="enable_review_labels_effort"></a>`enable_review_labels_effort`: if set to true, the tool will publish a 'Review effort [1-5]: x' label. Default is true.
-
-!!! example "Auto-approval"
-    The review tool can approve a PR when a specific comment, `/review auto_approve` is invoked.
-
-    - <a name="enable_auto_approval"></a>`enable_auto_approval`: if set to true, the tool will approve the PR when invoked with the 'auto_approve' command. Default is false. This flag can be changed only from configuration file.
-    - <a name="maximal_review_effort"></a>`maximal_review_effort`: maximal effort level for auto-approval. If the PR's estimated review effort is above this threshold, the auto-approval will not run. Default is 5.
-
 ### Incremental Mode
 Incremental review only considers changes since the last PR-Agent review. This can be useful when working on the PR in an iterative manner, and you want to focus on the changes since the last review instead of reviewing the entire PR again.
 For invoking the incremental mode, the following command can be used:
@@ -103,6 +64,100 @@ The tool will first ask the author questions about the PR, and will guide the re
 
 ![reflection insights](https://codium.ai/images/pr_agent/reflection_insights.png){width=512}
 
+
+
+## Configuration options
+
+!!! example "General options"
+
+<table>
+  <tr>
+    <td><b>num_code_suggestions</b></td>
+    <td>Number of code suggestions provided by the 'review' tool. For manual comments, default is 4. For PR-Agent app auto tools, default is 0, meaning no code suggestions will be provided by the review tool, unless you manually edit pr_commands.</td>
+  </tr>
+  <tr>
+    <td><b>inline_code_comments</b></td>
+    <td>If set to true, the tool will publish the code suggestions as comments on the code diff. Default is false.</td>
+  </tr>
+  <tr>
+    <td><b>persistent_comment</b></td>
+    <td>If set to true, the review comment will be persistent, meaning that every new review request will edit the previous one. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>extra_instructions</b></td>
+    <td>Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".</td>
+  </tr>
+  <tr>
+    <td><b>enable_help_text</b></td>
+    <td>If set to true, the tool will display a help text in the comment. Default is true.</td>
+  </tr>
+</table>
+
+!!! example "Enable\\disable specific sub-sections"
+
+<table>
+  <tr>
+    <td><b>require_score_review</b></td>
+    <td>If set to true, the tool will add a section that scores the PR. Default is false.</td>
+  </tr>
+  <tr>
+    <td><b>require_tests_review</b></td>
+    <td>If set to true, the tool will add a section that checks if the PR contains tests. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>require_estimate_effort_to_review</b></td>
+    <td>If set to true, the tool will add a section that estimates the effort needed to review the PR. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>require_can_be_split_review</b></td>
+    <td>If set to true, the tool will add a section that checks if the PR contains several themes, and can be split into smaller PRs. Default is false.</td>
+  </tr>
+</table>
+
+!!! example "SOC2 ticket compliance 💎"
+
+This sub-tool checks if the PR description properly contains a ticket to a project management system (e.g., Jira, Asana, Trello, etc.), as required by SOC2 compliance. If not, it will add a label to the PR: "Missing SOC2 ticket".
+    
+<table>
+  <tr>
+    <td><b>require_soc2_ticket</b></td>
+    <td>If set to true, the SOC2 ticket checker sub-tool will be enabled. Default is false.</td>
+  </tr>
+  <tr>
+    <td><b>soc2_ticket_prompt</b></td>
+    <td>The prompt for the SOC2 ticket review. Default is: `Does the PR description include a link to ticket in a project management system (e.g., Jira, Asana, Trello, etc.) ?`. Edit this field if your compliance requirements are different.</td>
+  </tr>
+</table>
+
+!!! example "Adding PR labels"
+
+You can enable\disable the `review` tool to add specific labels to the PR:
+
+<table>
+  <tr>
+    <td><b>enable_review_labels_security</b></td>
+    <td>If set to true, the tool will publish a 'possible security issue' label if it detects a security issue. Default is true.</td>
+  </tr>
+  <tr>
+    <td><b>enable_review_labels_effort</b></td>
+    <td>If set to true, the tool will publish a 'Review effort [1-5]: x' label. Default is true.</td>
+  </tr>
+</table>
+
+!!! example "Auto-approval"
+
+If enabled, the `review` tool can approve a PR when a specific comment, `/review auto_approve`, is invoked.
+
+<table>
+  <tr>
+    <td><b>enable_auto_approval</b></td>
+    <td>If set to true, the tool will approve the PR when invoked with the 'auto_approve' command. Default is false. This flag can be changed only from configuration file.</td>
+  </tr>
+  <tr>
+    <td><b>maximal_review_effort</b></td>
+    <td>Maximal effort level for auto-approval. If the PR's estimated review effort is above this threshold, the auto-approval will not run. Default is 5.</td>
+  </tr>
+</table>
 
 ## Usage Tips
 

--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -11,11 +11,8 @@ There are three ways to set persistent configurations:
 
 In terms of precedence, wiki configurations will override local configurations, and local configurations will override global configurations.
 
-!!! tip "Edit only what you need"
-
-  Your configuration file should be minimal, and edit only the relevant values. Don't copy the entire configuration options, since it can lead to legacy problems when something changes.
-
-
+!!! tip "Tip: edit only what you need"
+    Your configuration file should be minimal, and edit only the relevant values. Don't copy the entire configuration options, since it can lead to legacy problems when something changes.
 
 ## Wiki configuration file 💎
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -25,7 +25,7 @@ ai_disclaimer=""  # Pro feature, full text for the AI disclaimer
 require_score_review=false
 require_tests_review=true
 require_estimate_effort_to_review=true
-require_can_be_split_review=false
+require_can_be_split_review=true
 # soc2
 require_soc2_ticket=false
 soc2_ticket_prompt="Does the PR description include a link to ticket in a project management system (e.g., Jira, Asana, Trello, etc.) ?"
@@ -36,10 +36,10 @@ ask_and_reflect=false
 #automatic_review=true
 persistent_comment=true
 extra_instructions = ""
-final_update_message = true
+final_update_message=false
 # review labels
 enable_review_labels_security=true
-enable_review_labels_effort=true
+enable_review_labels_effort=false
 # specific configurations for incremental review (/review -i)
 require_all_thresholds_for_incremental_review=false
 minimal_commits_for_incremental_review=0

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -55,17 +55,17 @@ publish_labels=true
 add_original_user_description=true
 generate_ai_title=false
 use_bullet_points=true
-extra_instructions = ""
-enable_pr_type=true
-final_update_message = true
+extra_instructions = "Write all descriptions in the imperative mood."
+enable_pr_type=false
+final_update_message=false
 enable_help_text=false
-enable_help_comment=true
+enable_help_comment=false
 # describe as comment
 publish_description_as_comment=false
 publish_description_as_comment_persistent=true
 ## changes walkthrough section
 enable_semantic_files_types=true
-collapsible_file_list='adaptive' # true, false, 'adaptive'
+collapsible_file_list='true' # true, false, 'adaptive'
 inline_file_summary=false # false, true, 'table'
 # markers
 use_description_markers=false
@@ -82,9 +82,9 @@ max_context_tokens=8000
 num_code_suggestions=4
 commitable_code_suggestions = false
 extra_instructions = ""
-rank_suggestions = false
+rank_suggestions=true
 enable_help_text=false
-persistent_comment=false
+persistent_comment=true
 # params for '/improve --extended' mode
 auto_extended_mode=true
 num_code_suggestions_per_chunk=5
@@ -95,7 +95,7 @@ final_clip_factor = 0.8
 
 [pr_add_docs] # /add_docs #
 extra_instructions = ""
-docs_style = "Sphinx Style" # "Google Style with Args, Returns, Attributes...etc", "Numpy Style", "Sphinx Style", "PEP257", "reStructuredText"
+docs_style = "Google" # "Google Style with Args, Returns, Attributes...etc", "Numpy Style", "Sphinx Style", "PEP257", "reStructuredText"
 
 [pr_update_changelog] # /update_changelog #
 push_changelog_changes=false

--- a/pr_agent/settings/ignore.toml
+++ b/pr_agent/settings/ignore.toml
@@ -4,6 +4,17 @@ glob = [
     # Ignore files and directories matching these glob patterns.
     # See https://docs.python.org/3/library/glob.html
     'vendor/**',
+    # Monorepo
+    'logs/**',
+    'venv/**',
+    'input/**',
+    'output/**',
+    # ems-frontend
+    'node_modules/**',
+    'dist/**',
+    'build/**',
+    'package-lock.json',
+    'src/gql/**',
 ]
 regex = [
     # Ignore files and directories matching these regex patterns.


### PR DESCRIPTION
### **Description**
- Enable splitting of PRs by setting `require_can_be_split_review` to true.
- Disable final update messages and review labels for effort to streamline the review process.
- Set extra instructions to use the imperative mood for all descriptions.
- Change collapsible file list to always be true and enable ranking of suggestions.
- Update the documentation style to "Google" for consistency or preference.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Update Review and Documentation Configuration Settings</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml
<li>Enable the requirement for PRs to be splittable.<br> <li> Disable the final update message and effort labels.<br> <li> Add imperative mood instruction for extra descriptions.<br> <li> Change collapsible file list setting to true and rank suggestions to <br>true.<br> <li> Update documentation style to "Google".<br>


</details>
    

  </td>
  <td><a href="https://github.com/emmettgreen/pr-agent/pull/7/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+11/-11</a>&nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>